### PR TITLE
Issue 12: Add Columns to /sites table results

### DIFF
--- a/src/web/development.Dockerfile
+++ b/src/web/development.Dockerfile
@@ -1,7 +1,5 @@
 FROM node:16-alpine3.15
 
-RUN npm install -g @vue/cli
-
 RUN mkdir -p /usr/src/web
 WORKDIR /usr/src/web
 

--- a/src/web/src/components/Sites/SitesTable.vue
+++ b/src/web/src/components/Sites/SitesTable.vue
@@ -72,7 +72,11 @@
 					:server-items-length="totalLength"
 					:footer-props="{ 'items-per-page-options': [20, 50, 100] }"
 					@click:row="goToSiteDetails"
-				/>
+				>
+					<template #item.communityId="{ value }">
+						<CommunityCell :community-id="value" />
+					</template>
+				</v-data-table>
 			</v-col>
 		</v-row>
 	</v-container>
@@ -80,14 +84,16 @@
 
 <script>
 import { cloneDeep, uniqueId } from 'lodash';
+import { mapActions } from 'vuex';
 
 import api from '@/apis/places-api';
 
 import AdvancedSearchForm from '@/components/Sites/sites-table/AdvancedSearchForm';
+import CommunityCell from '@/components/Sites/sites-table/CommunityCell';
 
 export default {
 	name: 'SitesTable',
-	components: { AdvancedSearchForm },
+	components: { AdvancedSearchForm, CommunityCell },
 	data: () => ({
 		advancedSearchQuery: {},
 		items: [],
@@ -107,13 +113,13 @@ export default {
 			return [
 				{ text: 'YHSI ID', value: 'yHSIId' },
 				{ text: 'Primary name', value: 'primaryName' },
-				{ text: 'Community', value: 'community.name' },
+				{ text: 'Community', value: 'communityId' },
 				{ text: 'Category', value: 'siteCategories' },
 				{ text: 'Status', value: 'status.text' },
 			];
 		},
 		searchQuery() {
-			if (!this.searchTerm) return {}
+			if (!this.searchTerm) return {};
 
 			// query format is operation: value
 			// operation is a custom operation defined in the back-end
@@ -129,6 +135,7 @@ export default {
 		},
 	},
 	mounted() {
+		this.initializeCommunities();
 		this.loading = true;
 		api
 			.getAll()
@@ -141,6 +148,7 @@ export default {
 			});
 	},
 	methods: {
+		...mapActions({ initializeCommunities: 'communities/initialize' }),
 		goToSiteDetails(value) {
 			this.$router.push(`/sites/${value.id}`);
 		},
@@ -153,7 +161,7 @@ export default {
 		},
 		doSearch() {
 			const data = cloneDeep(this.options);
-			data.query = {...this.searchQuery, ...this.advancedSearchQuery};
+			data.query = { ...this.searchQuery, ...this.advancedSearchQuery };
 
 			this.loading = true;
 			api
@@ -169,7 +177,7 @@ export default {
 		toggleAdvancedSearch() {
 			if (this.isShowingAdvancedSearch) {
 				this.advancedSearchQuery = {};
-				this.doSearch()
+				this.doSearch();
 			}
 			this.isShowingAdvancedSearch = !this.isShowingAdvancedSearch;
 		},

--- a/src/web/src/components/Sites/SitesTable.vue
+++ b/src/web/src/components/Sites/SitesTable.vue
@@ -115,7 +115,7 @@ export default {
 				{ text: 'Primary name', value: 'primaryName' },
 				{ text: 'Community', value: 'communityId' },
 				{ text: 'Category', value: 'siteCategories' },
-				{ text: 'Status', value: 'status.text' },
+				{ text: 'Status', value: 'status' },
 			];
 		},
 		searchQuery() {

--- a/src/web/src/components/Sites/SitesTable.vue
+++ b/src/web/src/components/Sites/SitesTable.vue
@@ -136,16 +136,6 @@ export default {
 	},
 	mounted() {
 		this.initializeCommunities();
-		this.loading = true;
-		api
-			.getAll()
-			.then(({ data, meta }) => {
-				this.items = data;
-				this.totalLength = meta.itemCount;
-			})
-			.finally(() => {
-				this.loading = false;
-			});
 	},
 	methods: {
 		...mapActions({ initializeCommunities: 'communities/initialize' }),

--- a/src/web/src/components/Sites/sites-table/CommunitiesFilter.vue
+++ b/src/web/src/components/Sites/sites-table/CommunitiesFilter.vue
@@ -20,28 +20,28 @@
 </template>
 
 <script>
-import { isEmpty } from 'lodash'
-
-import api from '@/apis/communities-api';
+import { isEmpty } from 'lodash';
+import { mapGetters } from 'vuex';
 
 export default {
 	name: 'CommunitiesFilter',
 	data: () => ({
-		communities: [],
 		communityIds: [],
 		includeFilter: true,
-		loading: false,
 	}),
 	computed: {
+		...mapGetters('communities', ['communities', 'loading']),
 		communitiesFilter() {
-			if (isEmpty(this.communityIds)) return {}
+			if (isEmpty(this.communityIds)) return {};
 
 			return {
 				[this.queryName]: this.communityIds,
 			};
 		},
-		queryName () {
-			return this.includeFilter ? 'includingCommunityIds' : 'excludingCommunityIds'
+		queryName() {
+			return this.includeFilter
+				? 'includingCommunityIds'
+				: 'excludingCommunityIds';
 		},
 		filterTypeIcon() {
 			return this.includeFilter
@@ -49,21 +49,10 @@ export default {
 				: 'mdi-filter-minus-outline';
 		},
 	},
-	mounted() {
-		this.loading = true;
-		api
-			.getAll()
-			.then(({ data }) => {
-				this.communities = data;
-			})
-			.finally(() => {
-				this.loading = false;
-			});
-	},
 	methods: {
 		toggleFilterType() {
-			this.includeFilter = !this.includeFilter
-			this.$emit('input', this.communitiesFilter)
+			this.includeFilter = !this.includeFilter;
+			this.$emit('input', this.communitiesFilter);
 		},
 	},
 };

--- a/src/web/src/components/Sites/sites-table/CommunityCell.vue
+++ b/src/web/src/components/Sites/sites-table/CommunityCell.vue
@@ -1,0 +1,38 @@
+<template>
+  <v-progress-circular
+    v-if="loading"
+    indeterminate
+    size="20"
+    width="2"
+  />
+  <span v-else>
+    {{ communityName }}
+  </span>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+
+export default {
+  name: 'CommunityCell',
+  components: {},
+  props: {
+    communityId: {
+      type: Number,
+      required: true,
+    },
+  },
+  data: () => ({}),
+  computed: {
+    ...mapGetters('communities', ['getById', 'loading']),
+    community() {
+      return this.getById(this.communityId) || {};
+    },
+    communityName() {
+      return this.community.name;
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/src/web/src/router/index.js
+++ b/src/web/src/router/index.js
@@ -361,14 +361,6 @@ const routes = [
     props: true
   },
   {
-    path: "/places",
-    name: "PlacesGrid",
-    component: PlacesGrid,
-    meta: {
-      requiresAuth: false
-    },
-  },
-  {
     path: "/places/view/:name",
     name: "placeView",
     component: PlacesForm,

--- a/src/web/src/store/communities.js
+++ b/src/web/src/store/communities.js
@@ -1,0 +1,51 @@
+import { isEmpty, keyBy } from 'lodash';
+
+import api from '@/apis/communities-api';
+
+const state = {
+	communities: [],
+	loading: false,
+};
+
+const getters = {
+	communitiesKeyedById() {
+		return keyBy(state.communities, 'id');
+	},
+	getById: (state, getters) => (id) => {
+		return getters.communitiesKeyedById[id];
+	},
+};
+
+const mutations = {
+	getAll() {
+		state.loading = true;
+		return api
+			.getAll()
+			.then(({ data }) => {
+				state.communities = data;
+				return state.communities;
+			})
+			.finally(() => {
+				state.loading = false;
+			});
+	},
+};
+
+const actions = {
+	initialize({ commit }) {
+		if (!isEmpty(state.communities) && !state.loading) return;
+
+		return commit('getAll');
+	},
+	refresh({ commit }) {
+		return commit('getAll');
+	},
+};
+
+export default {
+	namespaced: true,
+	state,
+	getters,
+	mutations,
+	actions,
+};

--- a/src/web/src/store/communities.js
+++ b/src/web/src/store/communities.js
@@ -8,12 +8,14 @@ const state = {
 };
 
 const getters = {
+	communities: (state) => state.communities,
 	communitiesKeyedById() {
 		return keyBy(state.communities, 'id');
 	},
 	getById: (state, getters) => (id) => {
 		return getters.communitiesKeyedById[id];
 	},
+	loading: (state) => state.loading,
 };
 
 const mutations = {

--- a/src/web/src/store/index.js
+++ b/src/web/src/store/index.js
@@ -2,6 +2,7 @@ import Vue from "vue";
 import Vuex from "vuex";
 
 import auth from "./auth";
+import communities from "@/store/communities"
 import profile from "./profile";
 import boats from "./boats";
 import alerts from "./alerts";
@@ -46,5 +47,5 @@ export default new Vuex.Store({
     siteHistory: state => state.siteHistory,
     search: state => state.search,
   },
-  modules: { auth, profile, boats, alerts, photos, users }
+  modules: { auth, communities, profile, boats, alerts, photos, users }
 });


### PR DESCRIPTION
Fixes #12 

# User Story
As a user, when I go to the /sites table view I can see the what community a "site" is located in.
As a user, when I go to the /sites table view I can see if a "site" has had an edit made to it that is awaiting approval.

# Implementation
As the number of communites is very small I opted to load this data via the Vuex store and populated the /sites table column on the front-end via a custom cell.
For the "site" status of "Editing" I built a custom SQL join in the back-end and returned this result with the other search results. This is effectively a custom "table view" of the "Place" data.

# Screenshots
![image](https://user-images.githubusercontent.com/23045206/160205735-77c3bfb8-8d81-4d03-8b1c-b1ab4a030bbb.png)
![image](https://user-images.githubusercontent.com/23045206/160205635-a217a55c-07db-4c5d-ba24-73e970ad1bec.png)

# Testing Instructions

1. Go the the [/sites table](http://localhost:8080/sites) table, check that the "Community" column is appropriately populated.
2. Go the the [/sites table](http://localhost:8080/sites) table, search for `115O` via the text search, and check that the "Status" column is occasionally populated.
> Note that you can also sort the results by the "Editing" status by clicking on the "Status" column header.
